### PR TITLE
Rework stream socket

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -81,6 +81,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="wivrn" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/client/application.h
+++ b/client/application.h
@@ -282,6 +282,8 @@ class application
 	bool debug_extensions_found = false;
 	std::atomic<bool> exit_requested = false;
 
+	std::string server_address;
+
 	std::mutex scene_stack_lock;
 	std::vector<std::shared_ptr<scene>> scene_stack;
 	std::shared_ptr<scene> last_scene;
@@ -433,5 +435,10 @@ public:
 	static uint32_t queue_family_index()
 	{
 		return instance_->vk_queue_family_index;
+	}
+
+	const std::string& get_server_address() const
+	{
+		return server_address;
 	}
 };

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -246,7 +246,7 @@ std::unique_ptr<wivrn_session> connect_to_session(const std::vector<wivrn_discov
 			}
 			catch(std::exception& e)
 			{
-				spdlog::warn("Cannot connect to {}", service.hostname);
+				spdlog::warn("Cannot connect to {}: {}", service.hostname, e.what());
 			}
 		}
 	}

--- a/client/scenes/stream.h
+++ b/client/scenes/stream.h
@@ -100,6 +100,7 @@ public:
 
 	virtual void render() override;
 
+	void operator()(to_headset::handshake&&) {};
 	void operator()(to_headset::video_stream_data_shard &&);
 	void operator()(to_headset::video_stream_parity_shard &&);
 	void operator()(to_headset::haptics &&);

--- a/client/wivrn_client.h
+++ b/client/wivrn_client.h
@@ -31,6 +31,8 @@ class wivrn_session
 	typed_socket<TCP, to_headset::control_packets, from_headset::control_packets> control;
 	typed_socket<UDP, to_headset::stream_packets, from_headset::stream_packets> stream;
 
+	void handshake();
+
 public:
 	std::variant<in_addr, in6_addr> address;
 

--- a/common/wivrn_packets.h
+++ b/common/wivrn_packets.h
@@ -26,8 +26,6 @@
 #include <netinet/in.h>
 #include <optional>
 #include <span>
-#include <string>
-#include <tuple>
 #include <variant>
 #include <vector>
 #include <openxr/openxr.h>
@@ -38,9 +36,8 @@ namespace xrt::drivers::wivrn
 template <typename T, typename Enable>
 struct serialization_traits;
 
-static const int control_port = 9757;
-static const int stream_client_port = 9757;
-static const int stream_server_port = 9758;
+// Default port for server to listen, both TCP and UDP
+static const int default_port = 9757;
 
 enum class device_id : uint8_t
 {
@@ -108,6 +105,10 @@ struct headset_info_packet
 	};
 	std::optional<audio_description> speaker;
 	std::optional<audio_description> microphone;
+};
+
+struct handshake
+{
 };
 
 struct tracking
@@ -186,11 +187,15 @@ struct feedback
 };
 
 using control_packets = std::variant<headset_info_packet, feedback, audio_data>;
-using stream_packets = std::variant<tracking, inputs, timesync_response>;
+using stream_packets = std::variant<handshake, tracking, inputs, timesync_response>;
 } // namespace from_headset
 
 namespace to_headset
 {
+
+struct handshake
+{
+};
 
 struct audio_stream_description
 {
@@ -303,8 +308,8 @@ struct timesync_query
 	std::chrono::nanoseconds query;
 };
 
+using control_packets = std::variant<handshake, audio_stream_description, video_stream_description, audio_data>;
 using stream_packets = std::variant<video_stream_data_shard, video_stream_parity_shard, haptics, timesync_query>;
-using control_packets = std::variant<audio_stream_description, video_stream_description, audio_data>;
 
 } // namespace to_headset
 

--- a/common/wivrn_sockets.cpp
+++ b/common/wivrn_sockets.cpp
@@ -242,21 +242,21 @@ xrt::drivers::wivrn::TCPListener::TCPListener(int port)
 	}
 }
 
-// std::pair<xrt::drivers::wivrn::deserialization_packet, sockaddr_in6> xrt::drivers::wivrn::UDP::receive_from_raw()
-// {
-// 	std::vector<uint8_t> buffer(2000);
-//
-// 	sockaddr_in6 addr;
-// 	socklen_t addrlen = sizeof(addr);
-//
-// 	ssize_t received = recvfrom(fd, buffer.data(), buffer.size(), 0, (sockaddr *)&addr, &addrlen);
-// 	if (received < 0)
-// 		throw std::system_error{errno, std::generic_category()};
-//
-// 	buffer.resize(received);
-//
-// 	return {deserialization_packet{buffer}, addr};
-// }
+std::pair<xrt::drivers::wivrn::deserialization_packet, sockaddr_in6> xrt::drivers::wivrn::UDP::receive_from_raw()
+{
+	std::vector<uint8_t> buffer(2000);
+
+	sockaddr_in6 addr;
+	socklen_t addrlen = sizeof(addr);
+
+	ssize_t received = recvfrom(fd, buffer.data(), buffer.size(), 0, (sockaddr *)&addr, &addrlen);
+	if (received < 0)
+		throw std::system_error{errno, std::generic_category()};
+
+	buffer.resize(received);
+
+	return {deserialization_packet{buffer}, addr};
+}
 
 xrt::drivers::wivrn::deserialization_packet xrt::drivers::wivrn::UDP::receive_raw()
 {

--- a/common/wivrn_sockets.h
+++ b/common/wivrn_sockets.h
@@ -25,7 +25,7 @@
 #include <memory>
 #include <mutex>
 #include <netinet/ip.h>
-#include <stdexcept>
+#include <exception>
 #include <utility>
 #include <vector>
 
@@ -88,6 +88,7 @@ public:
 	UDP();
 
 	deserialization_packet receive_raw();
+	std::pair<xrt::drivers::wivrn::deserialization_packet, sockaddr_in6> receive_from_raw();
 	void send_raw(const std::vector<uint8_t> & data);
 
 	void connect(in6_addr address, int port);

--- a/server/driver/wivrn_connection.cpp
+++ b/server/driver/wivrn_connection.cpp
@@ -19,15 +19,73 @@
 
 #include "wivrn_connection.h"
 #include "util/u_logging.h"
+#include <arpa/inet.h>
 #include <poll.h>
 
 using namespace std::chrono_literals;
 
-wivrn_connection::wivrn_connection(TCP && tcp, in6_addr address) :
+wivrn_connection::wivrn_connection(TCP && tcp) :
         control(std::move(tcp))
 {
-	stream.bind(stream_server_port);
-	stream.connect(address, stream_client_port);
+	sockaddr_in6 server_address;
+	socklen_t len = sizeof(server_address);
+	if (getsockname(control.get_fd(), (sockaddr*)&server_address, &len) < 0)
+	{
+		throw std::system_error(errno, std::system_category(), "Cannot get socket port");
+	}
+	int port = ntohs(((struct sockaddr_in6*)&server_address)->sin6_port);
+
+	sockaddr_in6 client_address;
+	len = sizeof(client_address);
+	if (getpeername(control.get_fd(), (sockaddr *)&client_address, &len) < 0)
+	{
+		throw std::system_error(errno, std::system_category(), "Cannot get client address");
+	}
+
+	// Wait for client to send handshake on UDP
+	auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+
+	stream.bind(port);
+
+	control.send(to_headset::control_packets(to_headset::handshake{}));
+
+	while (true)
+	{
+		pollfd fds[2] = {};
+		fds[0].events = POLLIN;
+		fds[0].fd = stream.get_fd();
+		fds[1].events = 0; // only check for errors on control socket
+		fds[1].fd = control.get_fd();
+
+		int r = ::poll(fds, std::size(fds), 1000);
+		if (r < 0)
+			throw std::system_error(errno, std::system_category());
+
+		if (fds[0].revents & (POLLHUP | POLLERR))
+			throw std::runtime_error("Error on stream socket");
+
+		if (fds[1].revents & (POLLHUP | POLLERR))
+			throw std::runtime_error("Error on control socket");
+
+		if (fds[0].revents & POLLIN)
+		{
+			auto [packet, peer_addr] = stream.receive_from_raw();
+			if (memcmp(&peer_addr.sin6_addr, &client_address.sin6_addr, sizeof(peer_addr.sin6_addr)) == 0)
+			{
+				int client_port = htons(peer_addr.sin6_port);
+				stream.connect(peer_addr.sin6_addr, client_port);
+				U_LOG_D("Stream socket connected, client port %d", client_port);
+				break;
+			}
+
+		}
+
+		if (std::chrono::steady_clock::now() > timeout)
+		{
+			throw std::runtime_error("No handshake received on stream socket");
+		}
+	}
+
 	try
 	{
 		// Set Expedited forwarding https://datatracker.ietf.org/doc/html/rfc3246
@@ -47,24 +105,6 @@ void wivrn_connection::send_control(const to_headset::control_packets & packet)
 void wivrn_connection::send_stream(const to_headset::stream_packets & packet)
 {
 	stream.send(packet);
-}
-
-std::optional<from_headset::stream_packets> wivrn_connection::poll_stream(int timeout)
-{
-	pollfd fds{};
-	fds.events = POLLIN;
-	fds.fd = stream.get_fd();
-
-	int r = ::poll(&fds, 1, timeout);
-	if (r < 0)
-		throw std::system_error(errno, std::system_category());
-
-	if (r > 0 && (fds.revents & POLLIN))
-	{
-		return stream.receive();
-	}
-
-	return {};
 }
 
 std::optional<from_headset::control_packets> wivrn_connection::poll_control(int timeout)

--- a/server/driver/wivrn_connection.h
+++ b/server/driver/wivrn_connection.h
@@ -32,14 +32,13 @@ class wivrn_connection
 	typed_socket<UDP, from_headset::stream_packets, to_headset::stream_packets> stream;
 
 public:
-	wivrn_connection(TCP && tcp, in6_addr address);
+	wivrn_connection(TCP && tcp);
 	wivrn_connection(const wivrn_connection &) = delete;
 	wivrn_connection & operator=(const wivrn_connection &) = delete;
 
 	void send_control(const to_headset::control_packets & packet);
 	void send_stream(const to_headset::stream_packets & packet);
 
-	std::optional<from_headset::stream_packets> poll_stream(int timeout);
 	std::optional<from_headset::control_packets> poll_control(int timeout);
 
 	template <typename T>

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -61,26 +61,18 @@ struct wivrn_comp_target_factory : public comp_target_factory
 	}
 };
 
-xrt::drivers::wivrn::wivrn_session::wivrn_session(xrt::drivers::wivrn::TCP && tcp, in6_addr & address) :
-        connection(std::move(tcp), address)
+xrt::drivers::wivrn::wivrn_session::wivrn_session(xrt::drivers::wivrn::TCP && tcp) :
+        connection(std::move(tcp))
 {
 }
 
 wivrn_system_devices * xrt::drivers::wivrn::wivrn_session::create_session(xrt::drivers::wivrn::TCP && tcp)
 {
-	sockaddr_in6 address;
-	socklen_t address_len = sizeof(address);
-	if (getpeername(tcp.get_fd(), (sockaddr *)&address, &address_len) < 0)
-	{
-		U_LOG_E("Cannot get peer address: %s", strerror(errno));
-		return nullptr;
-	}
-
 	std::shared_ptr<wivrn_session> self;
 	std::optional<xrt::drivers::wivrn::from_headset::control_packets> control;
 	try
 	{
-		self = std::shared_ptr<wivrn_session>(new wivrn_session(std::move(tcp), address.sin6_addr));
+		self = std::shared_ptr<wivrn_session>(new wivrn_session(std::move(tcp)));
 		while (not(control = self->connection.poll_control(-1)))
 		{}
 	}

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -64,7 +64,7 @@ class wivrn_session : public std::enable_shared_from_this<wivrn_session>
 
 	std::shared_ptr<audio_device> audio_handle;
 
-	wivrn_session(TCP && tcp, in6_addr & address);
+	wivrn_session(TCP && tcp);
 
 public:
 	static wivrn_system_devices *
@@ -73,6 +73,7 @@ public:
 	clock_offset
 	get_offset();
 
+	void operator()(from_headset::handshake&&) {}
 	void operator()(from_headset::headset_info_packet &&);
 	void operator()(from_headset::tracking &&);
 	void operator()(from_headset::inputs &&);

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -195,9 +195,9 @@ int inner_main(int argc, char * argv[])
 	{
 		try
 		{
-			avahi_publisher publisher(hostname().c_str(), "_wivrn._tcp", control_port);
+			avahi_publisher publisher(hostname().c_str(), "_wivrn._tcp", default_port);
 
-			TCPListener listener(control_port);
+			TCPListener listener(default_port);
 			bool client_connected = false;
 			bool sigint_received = false;
 


### PR DESCRIPTION
Stream socket on server now uses the same port as the control socket. Client does not assign a port to its stream socket, instead it sends a handshake packet at the beginning, the server reads the remote port from it.