### PR TITLE
Add missing <span> include in yuv_converter.cpp.

### DIFF
--- a/server/encoder/yuv_converter.cpp
+++ b/server/encoder/yuv_converter.cpp
@@ -20,6 +20,7 @@
 #include "yuv_converter.h"
 
 #include <map>
+#include <span>
 #include <vector>
 
 extern const std::map<std::string, std::vector<uint32_t>> shaders;


### PR DESCRIPTION
Addresses build failure:

```
server/encoder/yuv_converter.cpp:341:15: error: no member named 'span' in namespace 'std'
  341 |                 std::span{im_barriers.begin(), 2});
      |                 ~~~~~^
1 error generated.
```