### PR TITLE
skip ATW if only single stereo layer projected

### DIFF
--- a/server/driver/wivrn_comp_target.cpp
+++ b/server/driver/wivrn_comp_target.cpp
@@ -526,12 +526,28 @@ static VkResult comp_wivrn_present(struct comp_target * ct,
 	view_info.display_time = cn->cnx->get_offset().to_headset(desired_present_time_ns).count();
 	for (int eye = 0; eye < 2; ++eye)
 	{
-		xrt_relation_chain xrc{};
-		xrt_space_relation result{};
-		m_relation_chain_push_pose_if_not_identity(&xrc, &cn->c->base.slot.poses[eye]);
-		m_relation_chain_resolve(&xrc, &result);
-		view_info.fov[eye] = xrt_cast(cn->c->base.slot.fovs[eye]);
-		view_info.pose[eye] = xrt_cast(result.pose);
+		const auto &slot = cn->c->base.slot;
+		view_info.fov[eye] = xrt_cast(slot.fovs[eye]);
+		view_info.pose[eye] = xrt_cast(slot.poses[eye]);
+		if (slot.layer_count == 1 && 
+			slot.layers[0].data.type == XRT_LAYER_STEREO_PROJECTION &&
+			slot.layers[0].data.stereo.r.fov.angle_left != 0.0f)
+		{
+			// only stereo projection is visible, may skip ATW
+			const auto &stereo = slot.layers[0].data.stereo;
+			view_info.pose[eye] = xrt_cast(eye ? stereo.r.pose : stereo.l.pose);
+			cn->c->debug.atw_off = true;
+		}
+		else
+		{
+			// enable ATW
+			cn->c->debug.atw_off = false;
+			xrt_relation_chain xrc{};
+			xrt_space_relation result{};
+			m_relation_chain_push_pose_if_not_identity(&xrc, &slot.poses[eye]);
+			m_relation_chain_resolve(&xrc, &result);
+			view_info.pose[eye] = xrt_cast(result.pose);
+		}
 	}
 	cn->psc.cv.notify_all();
 


### PR DESCRIPTION
Reprojection is already done on client, so may skip it on server, passing untouched eye poses from app
