### PR TITLE
feat(client): resolution scale setting

### DIFF
--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -117,6 +117,11 @@ configuration::configuration(const std::string & path)
 		preferred_refresh_rate = val.get_double();
 	}
 
+	if (auto val = root["resolution_scale"]; val.is_double())
+	{
+		resolution_scale = val.get_double();
+	}
+
 	if (auto val = root["microphone"]; val.is_bool())
 		microphone = val.get_bool();
 
@@ -153,6 +158,7 @@ void configuration::save()
 	     << "\"show_performance_metrics\":" << std::boolalpha << show_performance_metrics;
 	if (preferred_refresh_rate != 0.)
 		json << ",\"preferred_refresh_rate\":" << preferred_refresh_rate;
+	json << ",\"resolution_scale\":" << resolution_scale;
 	json << ",\"microphone\":" << std::boolalpha << microphone;
 	json << ",\"passthrough_enabled\":" << std::boolalpha << passthrough_enabled;
 	json << "}";

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -41,6 +41,7 @@ public:
 
 	std::map<std::string, server_data> servers;
 	float preferred_refresh_rate = 0;
+	float resolution_scale = 1.0;
 	bool show_performance_metrics = false;
 	bool microphone = false;
 	bool passthrough_enabled = false;

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -648,6 +648,7 @@ void scenes::lobby::on_focused()
 	recenter_gui = true;
 
 	auto views = system.view_configuration_views(viewconfig);
+	stream_view = override_view(views[0], guess_model());
 	uint32_t width = views[0].recommendedImageRectWidth;
 	uint32_t height = views[0].recommendedImageRectHeight;
 

--- a/client/scenes/lobby.h
+++ b/client/scenes/lobby.h
@@ -81,6 +81,7 @@ class lobby : public scene_impl<lobby>
 	vk::Format swapchain_format;
 	xr::system::passthrough_type passthrough_supported;
 	xr::passthrough passthrough;
+	XrViewConfigurationView stream_view;
 
 	void update_server_list();
 

--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -360,6 +360,24 @@ void scenes::lobby::gui_settings()
 		}
 	}
 
+	{
+		const auto available_scales = {0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0};
+		const auto current = config.resolution_scale;
+		if (ImGui::BeginCombo("Resolution scale", fmt::format("{}", current).c_str()))
+		{
+			for (float scale: available_scales)
+			{
+				if (ImGui::Selectable(fmt::format("{}", scale).c_str(), scale == current) and scale != current)
+				{
+					config.resolution_scale = scale;
+					config.save();
+				}
+			}
+			ImGui::EndCombo();
+		}
+		vibrate_on_hover();
+	}
+
 	if (ImGui::Checkbox("Enable microphone", &config.microphone))
 	{
 #ifdef __ANDROID__

--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -363,11 +363,13 @@ void scenes::lobby::gui_settings()
 	{
 		const auto available_scales = {0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0};
 		const auto current = config.resolution_scale;
-		if (ImGui::BeginCombo("Resolution scale", fmt::format("{}", current).c_str()))
+		const auto width = stream_view.recommendedImageRectWidth;
+		const auto height = stream_view.recommendedImageRectHeight;
+		if (ImGui::BeginCombo("Resolution scale", fmt::format("{} - {}x{} per eye", current, (int)(width * current), (int)(height * current)).c_str()))
 		{
 			for (float scale: available_scales)
 			{
-				if (ImGui::Selectable(fmt::format("{}", scale).c_str(), scale == current) and scale != current)
+				if (ImGui::Selectable(fmt::format("{} - {}x{} per eye", scale, (int)(width * scale), (int)(height * scale)).c_str(), scale == current) and scale != current)
 				{
 					config.resolution_scale = scale;
 					config.save();

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -86,6 +86,11 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 	auto view = self->system.view_configuration_views(self->viewconfig)[0];
 	view = override_view(view, guess_model());
 
+	auto resolution_scale = application::get_config().resolution_scale;
+
+	view.recommendedImageRectWidth *= resolution_scale;
+	view.recommendedImageRectHeight *= resolution_scale;
+
 	info.recommended_eye_width = view.recommendedImageRectWidth;
 	info.recommended_eye_height = view.recommendedImageRectHeight;
 


### PR DESCRIPTION
I'm trying to add a simple select box to be able to adjust the resolution on the client.

Except for some reason an app restart is required. If connecting to a stream right after setting this, it'll create the stream swapchain with a res that's way off. Any tips on what that could be?