### PR TITLE
update monado to 24.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ FetchContent_Declare(imgui         EXCLUDE_FROM_ALL URL https://github.com/ocorn
 # Server dependencies
 FetchContent_Declare(monado
     GIT_REPOSITORY   https://gitlab.freedesktop.org/monado/monado
-    GIT_TAG          598080453545c6bf313829e5780ffb7dde9b79dc
+    GIT_TAG          28cb225be12a8a55c221f22103c235aff6de3883
     PATCH_COMMAND    ${CMAKE_CURRENT_LIST_DIR}/patches/apply.sh ${CMAKE_CURRENT_LIST_DIR}/patches/monado/
     EXCLUDE_FROM_ALL
     )


### PR DESCRIPTION
straightforward update, was testing this for the past couple of days with no issues.

mostly wanting it because of the added `MNDX_xdev_space` extension, which will be needed when experimenting with tracker support