### PR TITLE
Fix building without systemd and with asserts enabled

### DIFF
--- a/server/main.cpp
+++ b/server/main.cpp
@@ -129,7 +129,7 @@ int inner_main(int argc, char * argv[], bool use_systemd)
 #ifdef WIVRN_USE_SYSTEMD
 	create_listen_socket();
 #else
-	assert(not systemd);
+	assert(not use_systemd);
 #endif
 
 	u_trace_marker_init();


### PR DESCRIPTION
When building v0.17 in Gentoo from the guru repository, I got the following error: 

main.cpp:132:20: error: 'systemd' was not declared in this scope; did you mean 'system'?
  132 | assert(not systemd);

I think it should be use_systemd instead of systemd