### PR TITLE
move eye tracker to its own device

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(wivrn-server
 		driver/wivrn_pacer.cpp
 		driver/wivrn_comp_target.cpp
 		driver/wivrn_controller.cpp
+		driver/wivrn_eye_tracker.cpp
 		driver/pose_list.cpp
 		driver/view_list.cpp
 		driver/hand_joints_list.cpp

--- a/server/driver/wivrn_eye_tracker.cpp
+++ b/server/driver/wivrn_eye_tracker.cpp
@@ -1,0 +1,112 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2024  Guillaume Meunier <guillaume.meunier@centraliens.net>
+ * Copyright (C) 2024  Patrick Nicolas <patricknicolas@laposte.net>
+ * Copyright (C) 2024  galister <galister@librevr.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "wivrn_eye_tracker.h"
+
+#include "wivrn_packets.h"
+#include "xrt/xrt_defines.h"
+#include "xrt/xrt_device.h"
+
+#include "util/u_logging.h"
+
+#include <cmath>
+#include <cstdint>
+#include <openxr/openxr.h>
+
+static void wivrn_eye_tracker_destroy(xrt_device * xdev);
+
+static void wivrn_eye_tracker_update_inputs(xrt_device * xdev);
+
+static void wivrn_eye_tracker_get_tracked_pose(xrt_device * xdev,
+                                               xrt_input_name name,
+                                               uint64_t at_timestamp_ns,
+                                               xrt_space_relation * out_relation);
+
+wivrn_eye_tracker::wivrn_eye_tracker(xrt_device * hmd,
+                                     std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx) :
+        xrt_device{}, gaze(device_id::EYE_GAZE), cnx(cnx)
+{
+	xrt_device * base = this;
+	base->tracking_origin = hmd->tracking_origin;
+
+	base->update_inputs = wivrn_eye_tracker_update_inputs;
+	base->get_tracked_pose = wivrn_eye_tracker_get_tracked_pose;
+	base->destroy = wivrn_eye_tracker_destroy;
+	name = XRT_DEVICE_EYE_GAZE_INTERACTION;
+	device_type = XRT_DEVICE_TYPE_EYE_TRACKER;
+	eye_gaze_supported = true;
+
+	// Print name.
+	strcpy(str, "WiVRn Eye Tracker");
+	strcpy(serial, "WiVRn Eye Tracker");
+
+	gaze_input.active = true;
+	gaze_input.name = XRT_INPUT_GENERIC_EYE_GAZE_POSE;
+
+	// Setup input.
+	inputs = &gaze_input;
+	input_count = 1;
+}
+
+void wivrn_eye_tracker::update_inputs()
+{
+	// Empty
+}
+
+xrt_space_relation wivrn_eye_tracker::get_tracked_pose(xrt_input_name name, uint64_t at_timestamp_ns)
+{
+	if (name == XRT_INPUT_GENERIC_EYE_GAZE_POSE)
+	{
+		auto [_, relation] = gaze.get_at(at_timestamp_ns);
+		return relation;
+	}
+
+	U_LOG_E("Unknown input name");
+	return {};
+}
+
+void wivrn_eye_tracker::update_tracking(const from_headset::tracking & tracking, const clock_offset & offset)
+{
+	gaze.update_tracking(tracking, offset);
+}
+
+/*
+ *
+ * Functions
+ *
+ */
+
+static void wivrn_eye_tracker_destroy(xrt_device * xdev)
+{
+	static_cast<wivrn_eye_tracker *>(xdev)->unregister();
+}
+
+static void wivrn_eye_tracker_update_inputs(xrt_device * xdev)
+{
+	static_cast<wivrn_eye_tracker *>(xdev)->update_inputs();
+}
+
+static void wivrn_eye_tracker_get_tracked_pose(xrt_device * xdev,
+                                               xrt_input_name name,
+                                               uint64_t at_timestamp_ns,
+                                               xrt_space_relation * out_relation)
+{
+	*out_relation = static_cast<wivrn_eye_tracker *>(xdev)->get_tracked_pose(name, at_timestamp_ns);
+}

--- a/server/driver/wivrn_eye_tracker.h
+++ b/server/driver/wivrn_eye_tracker.h
@@ -1,0 +1,53 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2024  Guillaume Meunier <guillaume.meunier@centraliens.net>
+ * Copyright (C) 2024  Patrick Nicolas <patricknicolas@laposte.net>
+ * Copyright (C) 2024  galister <galister@librevr.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "wivrn_packets.h"
+#include "xrt/xrt_defines.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_tracking.h"
+
+#include "pose_list.h"
+#include "wivrn_session.h"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+class wivrn_eye_tracker : public xrt_device
+{
+	std::mutex mutex;
+	xrt_input gaze_input;
+	pose_list gaze;
+
+	std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx;
+
+public:
+	wivrn_eye_tracker(xrt_device * hmd, std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx);
+	void unregister()
+	{
+		cnx = nullptr;
+	}
+
+	void update_inputs();
+	void update_tracking(const from_headset::tracking &, const clock_offset &);
+	xrt_space_relation get_tracked_pose(xrt_input_name name, uint64_t at_timestamp_ns);
+};

--- a/server/driver/wivrn_hmd.h
+++ b/server/driver/wivrn_hmd.h
@@ -47,7 +47,6 @@ class wivrn_hmd : public xrt_device
 	};
 
 	view_list views;
-	pose_list gaze;
 	std::array<to_headset::video_stream_description::foveation_parameter, 2> foveation_parameters{};
 
 	std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx;

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -32,6 +32,7 @@
 
 class wivrn_hmd;
 class wivrn_controller;
+class wivrn_eye_tracker;
 struct audio_device;
 
 struct u_system;
@@ -79,6 +80,7 @@ class wivrn_session : public std::enable_shared_from_this<wivrn_session>
 	std::unique_ptr<wivrn_hmd> hmd;
 	std::unique_ptr<wivrn_controller> left_hand;
 	std::unique_ptr<wivrn_controller> right_hand;
+	std::unique_ptr<wivrn_eye_tracker> eye_tracker;
 	wivrn_comp_target * comp_target;
 
 	clock_offset_estimator offset_est;


### PR DESCRIPTION
Apparently `EXT_eye_gaze_interaction` needs its own `xrt_device` with the `name` field set to `XRT_DEVICE_EYE_GAZE_INTERACTION`.

This time I've actually tested this and it checks out.