### PR TITLE
Fix pulseaudio backend thread exiting before reconnect

### DIFF
--- a/server/audio/audio_pulse.cpp
+++ b/server/audio/audio_pulse.cpp
@@ -337,7 +337,16 @@ struct pulse_device : public audio_device
 					size -= remainder;              // size of data to send
 					packet.payload = std::span<uint8_t>(buffer.begin(), size);
 					packet.timestamp = session.get_offset().to_headset(os_monotonic_get_ns());
-					session.send_stream(packet);
+					
+					try
+					{
+						session.send_control(packet);
+					}
+					catch (std::exception & e)
+					{
+						U_LOG_D("Failed to send audio data: %s", e.what());
+					}
+
 					// put the remaining data at the beginning of the buffer
 					memmove(buffer.data(), buffer.data() + size, remainder);
 				}


### PR DESCRIPTION
When reconnecting to a existing wivrn session and running on the pulseaudio backend, game audio stops working due to the speaker thread trying to send audio packets without catching exceptions about being disconnected.

Also pulseaudio backend used `send_stream` for sending audio packets while pipewire backend uses `send_control` so i changed pulse to use `send_control` as well for consistency.